### PR TITLE
docs: update package READMEs for Node 24 and npm

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # `mtfh-frontend`
 
-This monorepo contains various reusable packages, originally built to facilitate repition
-within MTFH's micro-frontend architecture.
+This monorepo contains various reusable packages, originally built to facilitate
+repetition within MTFH's micro-frontend architecture.
 
 ## Requirements
 
@@ -36,7 +36,7 @@ npm run build
 
 ## Exploring
 
-Look through the various `packages/*` in this monorepo and their detaild Readmes.
+Look through the various `packages/*` in this monorepo and their detailed Readmes.
 
 ## Contributing
 

--- a/packages/cli/readme.md
+++ b/packages/cli/readme.md
@@ -1,48 +1,48 @@
 # `@hackney/mtfh-cli`
 
-A cli to help manage micro-frontend orchestration for MTFH.
+A CLI to help manage micro-frontend orchestration for MTFH.
 
 Requires **Node.js 24+**.
 
 ## Install
 
 ```bash
-$ npx @hackney/mtfh-cli
-$ npm install -g @hackney/mtfh-cli
-$ yarn global add @hackney/mtfh-cli
+npx @hackney/mtfh-cli
+npm install -g @hackney/mtfh-cli
 ```
 
 ## CLI
 
 ```
 Usage
-    $ mtfh-cli <command>
+  $ mtfh-cli <command>
 
-  Commands
-    - install
-    - new [directory]
-    - run [...apps]
-    - register [directory]
-    - upgrade
+Commands
+  - install
+  - new [directory]
+  - run [...apps]
+  - register [directory]
+  - upgrade
 
-	Examples
-	  $ mtfh-cli new mtfh-frontend-project
-      - Starts the scaffolding in a new folder in cwd called mtfh-frontend-project
-    $ mtfh-cli run
-      - Starts only the required apps
-    $ mtfh-cli run search tenure
-      - Starts the required apps, plus mtfh-frontend-search and mtfh-frontend-tenure
-    $ mtfh-cli run mtfh
-      - Starts the required apps, plus all apps prefixed with mtfh (most if not all)
+Examples
+  $ mtfh-cli new mtfh-frontend-project
+    - Starts scaffolding in a new folder in cwd called mtfh-frontend-project
+  $ mtfh-cli run
+    - Starts only the required apps
+  $ mtfh-cli run search tenure
+    - Starts the required apps, plus mtfh-frontend-search and mtfh-frontend-tenure
+  $ mtfh-cli run mtfh
+    - Starts the required apps, plus all apps prefixed with mtfh (most if not all)
 ```
 
 ## Requirements
 
-Node 14 - https://nodejs.org/en/ Github Personal Access Token -
-https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token
-
-NB: Most MTFH frontend repos are currently using `yarn` so it would be important to have
-`yarn` installed as a global.
+- **Node.js 24+** — https://nodejs.org/
+- **GitHub Personal Access Token** —
+  https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token
+- **npm** (workspaces). Some existing MTFH frontend apps may still use Yarn; the CLI
+  detects `yarn.lock` vs `package-lock.json` when installing dependencies in those
+  projects.
 
 ## Commands
 
@@ -51,12 +51,12 @@ NB: Most MTFH frontend repos are currently using `yarn` so it would be important
 Install existing micro-frontends into a given directory. All microfrontends are prefixed
 with `mtfh-frontend-`.
 
-- Follow the prompts by adding and securing your github personal access token.
+- Follow the prompts by adding and securing your GitHub personal access token.
 - Select the micro-frontends you want to add, using the arrow keys and space to select.
   Enter to confirm.
-- The repos will be git cloned, some repo's could be private so make sure you have git ssh
+- The repos will be git cloned; some repos may be private so make sure you have git SSH
   configured in a terminal.
-- Optionally install all projects dependencies.
+- Optionally install all project dependencies.
 
 This step will create a `.mtfh` config folder in your home folder. An encrypted version of
 your access token is stored in `.mtfh/config.json`. Feel free to delete. All registered
@@ -64,9 +64,9 @@ micro-frontends are stored in `.mtfh/app.json`.
 
 ### Run
 
-Orchestrates micro-frontends to start developing locally. Not all Micro-frontends need to
-run for you to be able to start working on a piece of functionality. We do enforce a few
-as required. Root, Auth, Header, and Common.
+Orchestrates micro-frontends to start developing locally. Not all micro-frontends need to
+run for you to be able to start working on a piece of functionality. We enforce a few as
+required: Root, Auth, Header, and Common.
 
 The `run` command accepts multiple arguments to help you spin up the right
 micro-frontends. The arguments simply get pattern matched to the registered
@@ -92,15 +92,15 @@ mtfh-cli run mtfh
 
 ### Register
 
-If you manually create or clone a project they wont automatically be registered with the
-cli. This command helps add it so it can be available in `run`.
+If you manually create or clone a project they won't automatically be registered with the
+CLI. This command helps add it so it can be available in `run`.
 
 ### New
 
-Creates and registers a micro-frontend using the yeoman generator. See
+Creates and registers a micro-frontend using the Yeoman generator. See
 `packages/generator`.
 
 ### Upgrade
 
-A shortcut to our yeoman generator that makes sure all the micro-frontend's dependencies
+A shortcut to our Yeoman generator that makes sure all the micro-frontend's dependencies
 match the defined state. See `packages/generator`.

--- a/packages/create-mfe/README.md
+++ b/packages/create-mfe/README.md
@@ -1,6 +1,8 @@
 # `@hackney/create-mfe`
 
-A collection of scaffolding utilities for Micro-frontends
+Scaffolding utilities for Hackney micro-frontends.
+
+Requires **Node.js 24+**.
 
 ## Installation
 
@@ -8,21 +10,24 @@ A collection of scaffolding utilities for Micro-frontends
 npx @hackney/create-mfe
 ```
 
-Alternatively with yarn:
+Optionally pass a path for the new app directory:
 
 ```bash
-yarn create @hackney/mfe
-```
-
-The script will accept a path argument for the intialising directory:
-
-```
-yarn create @hackney/mfe my-app
+npx @hackney/create-mfe my-app
 ```
 
 ## Usage
 
 The current scaffolding utilities are:
 
-1. Application - Create a new React Micro-frontend application.
-2. Upgrade - Upgrade an existing Application's dependencies to the latest specified.
+1. **Application** — create a new React micro-frontend application.
+2. **Upgrade** — upgrade an existing application's dependencies to the latest specified
+   versions.
+
+Under the hood this wraps [`@hackney/generator-mfe`](../generator). You can also use
+`mtfh-cli new` / `mtfh-cli upgrade`.
+
+## Linked versioning
+
+`@hackney/create-mfe` and `@hackney/generator-mfe` are versioned together via Release
+Please linked versions. See the root [README](../../README.md).

--- a/packages/cypress/README.md
+++ b/packages/cypress/README.md
@@ -1,13 +1,13 @@
 # `@hackney/mtfh-cypress`
 
-This package is intended to be used in conjuction with a live environment that uses
-import-maps to resolve micro-frontends. It will stub an import-map with the url defined in
+This package is intended to be used in conjunction with a live environment that uses
+import-maps to resolve micro-frontends. It will stub an import-map with the URL defined in
 the env. This allows us to test a local MFE against an environment without deploying,
 while having access to the entire environment.
 
 Lifecycle:
 
-1. Before All hook visits the baseURL as an authenticated hackney user to intercept
+1. Before All hook visits the baseURL as an authenticated Hackney user to intercept
    configuration (feature toggles) and store as a fixture.
 2. Do a request to `${DEV_URL}/import-map.json` and store the output.
 3. Before Each hook will intercept all import-map.json requests and determine which
@@ -15,31 +15,38 @@ Lifecycle:
 
 ## Installation
 
-```
-yarn add @hackney/mtfh-cli
-yarn add dotenv cypress -D
+```bash
+npm install @hackney/mtfh-cypress
+npm install -D dotenv cypress
 ```
 
 ## Usage
 
 This library provides both a configuration plugin as well as a collection of hooks and
-commands. Plugins run in the node context within cypress and commands run in the browser,
+commands. Plugins run in the Node context within Cypress and commands run in the browser,
 so we have to wire them up separately.
 
 ### Plugin
 
-In `cypress/plugins/index.js`
+In `cypress.config.js` (Cypress 10+):
 
 ```js
+const { defineConfig } = require("cypress");
 const { configPlugin } = require("@hackney/mtfh-cypress/plugin");
 
-module.exports = (on, config) => {
-  let mtfhConfig = configPlugin(on, config);
-  return mtfhConfig;
-};
+module.exports = defineConfig({
+  e2e: {
+    setupNodeEvents(on, config) {
+      return configPlugin(on, config);
+    },
+    env: {
+      DEV_URL: "http://localhost:9000",
+    },
+  },
+});
 ```
 
-Create a `.env` file in the root of your project.
+Create a `.env` file in the root of your project:
 
 ```
 CYPRESS_ENVIRONMENT=development
@@ -47,22 +54,11 @@ CYPRESS_BASE_URL=https://manage-my-home-development.hackney.gov.uk
 CYPRESS_AUTH_TOKEN=token
 ```
 
-You'll want to configure these variables in your circle ci pipeline to match your
-environment.
-
-In `cypress.json`
-
-```js
-{
-  "env": {
-    "DEV_URL": "http://localhost:9000",
-  }
-}
-```
+Configure these variables in your CI pipeline to match your environment.
 
 ### Hooks & Commands
 
-In `cypress/support/index.js`
+In `cypress/support/e2e.js` (or `cypress/support/index.js`):
 
 ```js
 import "@hackney/mtfh-cypress";
@@ -86,26 +82,27 @@ cy.skipOnEnv("development");
 cy.skipOnToggle("MMH.CreateTenure", true);
 ```
 
-To skip a collection of tests encapsulate the tests in a `describe`
+To skip a collection of tests encapsulate the tests in a `describe`:
 
 ```js
-describe('Collection of tests', () => {
+describe("Collection of tests", () => {
   before(() => {
-    cy.skipOnToggle('MMH.CreateTenure', true);
-  })
+    cy.skipOnToggle("MMH.CreateTenure", true);
+  });
 
-  it('creates a tenure', () => {
-    ...
-  })
-})
+  it("creates a tenure", () => {
+    // ...
+  });
+});
 ```
 
 ## Audits
 
-We provide commands for testing performance as well as accessibility.
+We provide commands for performance and accessibility testing using **Lighthouse** and
+**Pa11y** directly (no `@cypress-audit/*` packages).
 
 ```js
-// Equalvalent of testing for mobile
+// Equivalent of testing for mobile
 cy.lighthouse({
   seo: 0,
   "best-practices": 100,
@@ -125,35 +122,32 @@ cy.lighthouseDesktop({
 cy.pa11y({ actions: ["wait for element h1 to be added"] });
 ```
 
-NB: It's important to note that Lighthouse's performance metrics can't really be taken as
-an indication of the actual report. This plugin is intended to run a local version of the
-micro-frontend so we can test against it before deploying. Ie. we will be testing against
-an app that isn't served by our architecture. You can however use it as a quality gate to
-ensure new changes don't reduce the scores. We recommend manual performance testing in
-live environments to get real world values.
+NB: Lighthouse performance metrics from this plugin can't really be taken as an indication
+of the live report. This package is intended to run a local version of the micro-frontend
+so we can test against it before deploying — i.e. against an app that isn't served by our
+architecture. You can use it as a quality gate so new changes don't reduce the scores. We
+recommend manual performance testing in live environments for real-world values.
 
 ## Additions
 
 This library comes with the following preconfigured:
 
-- @testing-libray/cypress
-- cypress-audit
-- cypress-terminal-report
+- `@testing-library/cypress`
+- `lighthouse` and `pa11y` (via custom Cypress tasks)
+- `cypress-terminal-report`
 
 ## Configuration
 
-The config plugin will override a few `cypress.json` defaults that align to the
-requirements more closely.
-
-Such as:
+The config plugin overrides a few Cypress defaults that align to the requirements more
+closely, such as:
 
 ```js
 {
-  "retries": {
-    "runMode": 2,
-    "openMode": 0,
+  retries: {
+    runMode: 2,
+    openMode: 0,
   },
-  "chromeWebSecurity": false,
-  "defaultCommandTimeout": 10000,
+  chromeWebSecurity: false,
+  defaultCommandTimeout: 10000,
 }
 ```

--- a/packages/eslint-config/README.md
+++ b/packages/eslint-config/README.md
@@ -1,23 +1,38 @@
 # `@hackney/eslint-config`
 
-Eslint config for TS and React projects.
+ESLint config for TypeScript and React projects.
 
 ## Installation
 
 ```bash
-npm install @hackney/eslint-config -D
-yarn add @hackney/eslint-config -D
+npm install -D @hackney/eslint-config
 ```
 
-Add the library dependencies
+Install the peer dependencies (versions should satisfy the ranges declared by this
+package):
 
 ```bash
-yarn add @typescript-eslint/eslint-plugin eslint eslinit-config-airbnb eslint-config-airbnb-typescript eslint-config-prettier eslint-config-react eslint-plugin-import eslint-plugin-jest eslint-plugin-jsx-a11y eslint-plugin-prettier eslint-plugin-react eslint-plugin-react-hooks eslint-plugin-testing-library prettier -D
+npm install -D \
+  eslint@^8.57.0 \
+  @typescript-eslint/eslint-plugin@^7.18.0 \
+  @typescript-eslint/parser@^7.18.0 \
+  eslint-config-airbnb@^19.0.4 \
+  eslint-config-airbnb-typescript@^18.0.0 \
+  eslint-config-prettier@^9.1.0 \
+  eslint-config-react@^1.1.7 \
+  eslint-plugin-import@^2.31.0 \
+  eslint-plugin-jest@^28.9.0 \
+  eslint-plugin-jsx-a11y@^6.10.2 \
+  eslint-plugin-prettier@^5.2.1 \
+  eslint-plugin-react@^7.37.2 \
+  eslint-plugin-react-hooks@^5.0.0 \
+  eslint-plugin-testing-library@^6.4.0 \
+  prettier@^3.4.0
 ```
 
 ## Usage
 
-For React based projects configure a `.eslintrc` file:
+For React-based projects, configure a `.eslintrc` file:
 
 ```json
 {
@@ -25,7 +40,7 @@ For React based projects configure a `.eslintrc` file:
 }
 ```
 
-For non React based TS projects:
+For non-React TypeScript projects:
 
 ```json
 {

--- a/packages/generator/README.md
+++ b/packages/generator/README.md
@@ -1,11 +1,32 @@
-# `@hackney/generator`
+# `@hackney/generator-mfe`
 
-> TODO: description
+Yeoman generator for Hackney micro-frontend applications. Used by
+[`@hackney/create-mfe`](../create-mfe) and `@hackney/mtfh-cli` (`new` / `upgrade`).
+
+Requires **Node.js 24+**.
 
 ## Usage
 
-```
-const generator = require('@hackney/generator');
+Most of the time you should not run this package directly. Prefer:
 
-// TODO: DEMONSTRATE API
+```bash
+npx @hackney/create-mfe
+# or
+mtfh-cli new my-app
+mtfh-cli upgrade
 ```
+
+### Direct Yeoman usage
+
+```bash
+npm install -g yo @hackney/generator-mfe
+yo @hackney/mfe
+```
+
+The generator scaffolds a React single-spa micro-frontend with Hackney defaults (webpack,
+TypeScript, ESLint, Prettier, Jest, Cypress wiring, and `@mtfh/common` integration).
+
+## Linked versioning
+
+`@hackney/generator-mfe` and `@hackney/create-mfe` are versioned together via Release
+Please linked versions. See the root [README](../../README.md).

--- a/packages/generator/src/application/templates/README.md
+++ b/packages/generator/src/application/templates/README.md
@@ -1,7 +1,6 @@
 # <%= name %>
 
-A Micro-frontend application for Hackney.
-
+A micro-frontend application for Hackney.
 
 ## Installation
 
@@ -11,9 +10,10 @@ A Micro-frontend application for Hackney.
 <%= packageManager %> install
 ```
 
-2. Complete instructions on adding a new Micro-frontend to the (Root App)[https://github.com/LBHackney-IT/mtfh-frontend-root#overview]
+2. Complete instructions on adding a new micro-frontend to the
+   [Root App](https://github.com/LBHackney-IT/mtfh-frontend-root#overview).
 
-3. Use the `mtfh-cli` to launch the app
+3. Use the `mtfh-cli` to launch the app:
 
 ```bash
 mtfh-cli <%= projectName %>

--- a/packages/prettier-config/README.md
+++ b/packages/prettier-config/README.md
@@ -1,18 +1,16 @@
 # `@hackney/prettier-config`
 
-A configuration for prettier, to create consistancy across Hackney projects.
+A configuration for Prettier, to create consistency across Hackney projects.
 
 ## Usage
 
-Install package as a dev dependency:
+Install the package as a dev dependency:
 
-```
-npm install @hackney/prettier-config -D
-// or
-yarn add @hackney/prettier-config -D
+```bash
+npm install -D @hackney/prettier-config
 ```
 
-Create a `.prettierrc.js` file in the root of your project.
+Create a `.prettierrc.js` file in the root of your project:
 
 ```js
 const prettierConfig = require("@hackney/prettier-config");

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -1,11 +1,65 @@
-# `react`
+# `@hackney/mtfh-react`
 
-> TODO: description
+LBH React design-system components for Modern Tools for Housing. Built on
+[lbh-frontend](https://github.com/LBHackney-IT/lbh-frontend) / GOV.UK Frontend styles and
+patterns.
+
+## Installation
+
+```bash
+npm install @hackney/mtfh-react
+```
+
+Peer dependencies (install in the consuming app):
+
+```bash
+npm install react react-dom react-router-dom formik
+```
+
+Supported React versions: **17 | 18 | 19**. React Router **5** is required.
 
 ## Usage
 
-```
-const react = require('react');
+Import the global reset once (usually in your app entry):
 
-// TODO: DEMONSTRATE API
+```ts
+import "@hackney/mtfh-react/reset.css";
 ```
+
+Then use components:
+
+```tsx
+import { Button, Dialog, Heading, Layout } from "@hackney/mtfh-react";
+
+export const Example = () => (
+  <Layout>
+    <Heading variant="h1">Hello</Heading>
+    <Button>Continue</Button>
+  </Layout>
+);
+```
+
+### Dialog
+
+```tsx
+import { Dialog, DialogActions, Button } from "@hackney/mtfh-react";
+
+<Dialog isOpen={open} onDismiss={() => setOpen(false)} title="Confirm">
+  <p>Are you sure?</p>
+  <DialogActions>
+    <Button onClick={() => setOpen(false)}>Close</Button>
+  </DialogActions>
+</Dialog>;
+```
+
+## Local development
+
+From the monorepo root:
+
+```bash
+npm ci
+npm run build
+npm run storybook
+```
+
+Storybook stories live under `packages/react/src/components/**/*.stories.tsx`.

--- a/packages/system/README.md
+++ b/packages/system/README.md
@@ -1,11 +1,33 @@
-# `system`
+# `@hackney/mtfh-system`
 
-> TODO: description
+Shared design tokens and breakpoint helpers for Modern Tools for Housing frontends.
+
+## Installation
+
+```bash
+npm install @hackney/mtfh-system
+```
 
 ## Usage
 
-```
-const system = require('system');
+```ts
+import { BREAKPOINTS, breakpoints, queries } from "@hackney/mtfh-system";
 
-// TODO: DEMONSTRATE API
+BREAKPOINTS.md; // 768
+queries.md; // "(min-width: 768px) and (max-width: 991px)"
+breakpoints.get("lg"); // 992
 ```
+
+### Breakpoints
+
+| Key  | Min width (px) |
+| ---- | -------------- |
+| base | 0              |
+| sm   | 480            |
+| md   | 768            |
+| lg   | 992            |
+| xl   | 1280           |
+| 2xl  | 1536           |
+
+`queries` maps each key to a CSS media-query string used by `@hackney/mtfh-react` hooks
+and `@hackney/mtfh-test-utils` render helpers.

--- a/packages/test-utils/README.md
+++ b/packages/test-utils/README.md
@@ -1,6 +1,8 @@
 # `test-utils`
 
-Testing utilities for Jest utilising the `@testing-library` and `mws` frameworks.
+Testing utilities for Jest utilising the `@testing-library` and `msw` frameworks.
+
+Supports React **17 | 18 | 19** and MSW **2**.
 
 ## Usage
 


### PR DESCRIPTION
## What
- Align package and root READMEs with the Node 24 / npm workspaces toolchain after PR #112
- Replace dummy docs for `@hackney/mtfh-react`, `@hackney/mtfh-system`, and `@hackney/generator-mfe`
- Fix outdated Cypress (`cypress.config.js`, lighthouse/pa11y), ESLint peer install list, and CLI Node 14 references