### PR TITLE
fix(ci): allow Storybook deploy to push gh-pages

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -34,8 +34,9 @@ jobs:
     needs: release-please
     if: ${{ needs.release-please.outputs.releases_created == 'true' }}
     runs-on: ubuntu-latest
+    # contents: write is required for JamesIves/github-pages-deploy-action to push gh-pages
     permissions:
-      contents: read
+      contents: write
     steps:
       - uses: actions/checkout@v6
         with:


### PR DESCRIPTION
## Summary
- Give the `publish-npm` job `contents: write` so `JamesIves/github-pages-deploy-action` can push to `gh-pages`
- Fixes `Permission denied to github-actions[bot]` (403) on the **Deploy Storybook** step after a release

## Test plan
- [ ] After merge, re-run the failed Release Please `publish-npm` job (or wait for the next release)
- [ ] Confirm **Deploy Storybook** succeeds and `gh-pages` updates