### PR TITLE
fix(mtfh-cli): correct subject-verb agreement in register docs

### DIFF
--- a/packages/cli/readme.md
+++ b/packages/cli/readme.md
@@ -92,7 +92,7 @@ mtfh-cli run mtfh
 
 ### Register
 
-If you manually create or clone a project they won't automatically be registered with the
+If you manually create or clone a project, it won't automatically be registered with the
 CLI. This command helps add it so it can be available in `run`.
 
 ### New


### PR DESCRIPTION
## Summary
- Fix pointless typo in `@hackney/mtfh-cli` register docs: \"a project they won't\" → \"a project, it won't\"
- Conventional `fix(mtfh-cli):` commit so Release Please opens a patch release PR after merge