### PR TITLE
ci: publish packages via npm OIDC trusted publisher

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -1,0 +1,139 @@
+# Trusted publisher workflow (OIDC). Only this filename may be registered on npmjs.com
+# for each @hackney/* package that this monorepo publishes.
+name: Publish npm package
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      channel:
+        description: >
+          "latest" publishes package.json versions as-is to the default npm tag
+          (production installs). "next" bumps each public package to a unique prerelease
+          version (e.g. 1.3.0-next.3) and publishes under the next tag for
+          release-candidate testing.
+        required: true
+        type: choice
+        options:
+          - latest
+          - next
+        default: latest
+      git_ref:
+        description:
+          Tag or ref to publish (e.g. @hackney/mtfh-react-v1.3.0, main, or release-please
+          branch)
+        required: true
+        default: main
+        type: string
+
+# Queue runs when Release Please creates multiple package releases from one merge.
+concurrency:
+  group: publish-npm
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+  id-token: write
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    # - npm-prerelease: manual @next / RC publishes only
+    # - npm-release: production @latest (Release Please + manual hotfix republish)
+    environment:
+      ${{ github.event_name == 'workflow_dispatch' && inputs.channel == 'next' &&
+      'npm-prerelease' || 'npm-release' }}
+    steps:
+      - name: Resolve publish target
+        id: target
+        run: |
+          if [ "${{ github.event_name }}" = "release" ]; then
+            echo "ref=${{ github.event.release.tag_name }}" >> "$GITHUB_OUTPUT"
+            echo "channel=latest" >> "$GITHUB_OUTPUT"
+          else
+            echo "ref=${{ inputs.git_ref }}" >> "$GITHUB_OUTPUT"
+            echo "channel=${{ inputs.channel }}" >> "$GITHUB_OUTPUT"
+          fi
+
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ steps.target.outputs.ref }}
+          fetch-depth: 0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version-file: ".nvmrc"
+          registry-url: https://registry.npmjs.org
+          package-manager-cache: false
+
+      - name: Install modules
+        run: npm ci
+
+      - name: Build packages
+        run: npm run build
+
+      - name: Run tests
+        run: npm run test:ci
+
+      - name: Resolve publish versions
+        id: version
+        run: |
+          CHANNEL="${{ steps.target.outputs.channel }}"
+
+          if [ "$CHANNEL" = "next" ]; then
+            for pkg_json in packages/*/package.json; do
+              NAME=$(node -p "require('./${pkg_json}').name")
+              PRIVATE=$(node -p "Boolean(require('./${pkg_json}').private)")
+              if [ "$PRIVATE" = "true" ]; then
+                continue
+              fi
+
+              BASE=$(node -p "require('./${pkg_json}').version")
+              PREFIX="${BASE}-next."
+              MAX_N=0
+              if VERSIONS=$(npm view "${NAME}" versions --json 2>/dev/null); then
+                MAX_N=$(echo "$VERSIONS" | jq --arg p "$PREFIX" '
+                  (if type == "array" then . else [.] end)
+                  | [.[] | select(startswith($p)) | .[$p | length:] | select(test("^[0-9]+$")) | tonumber]
+                  | max // 0
+                ')
+              fi
+              VERSION="${BASE}-next.$((MAX_N + 1))"
+              npm version "${VERSION}" --no-git-tag-version --workspace "${NAME}"
+              echo "Prepared ${NAME}@${VERSION}"
+            done
+          fi
+
+          echo "channel=${CHANNEL}" >> "$GITHUB_OUTPUT"
+          echo "Publishing workspace packages (dist-tag ${CHANNEL}) from ${{ steps.target.outputs.ref }}"
+
+      - name: Publish packages
+        run:
+          npx lerna publish from-package --yes --dist-tag "${{
+          steps.target.outputs.channel }}"
+
+      - name: Build Storybook
+        if: ${{ steps.target.outputs.channel == 'latest' }}
+        run: npm run build-storybook
+
+      - name: Deploy Storybook
+        if: ${{ steps.target.outputs.channel == 'latest' }}
+        uses: JamesIves/github-pages-deploy-action@v4
+        with:
+          branch: gh-pages
+          folder: storybook-static
+
+      - name: Summary
+        run: |
+          CHANNEL="${{ steps.target.outputs.channel }}"
+          REF="${{ steps.target.outputs.ref }}"
+          {
+            echo "### Packages published (trusted publisher / OIDC)"
+            echo ""
+            echo "- **Dist-tag:** \`${CHANNEL}\`"
+            echo "- **Ref:** \`${REF}\`"
+            echo ""
+            echo "Published via \`lerna publish from-package\` for versions not already on npm."
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -7,22 +7,8 @@ on:
     types: [published]
   workflow_dispatch:
     inputs:
-      channel:
-        description: >
-          "latest" publishes package.json versions as-is to the default npm tag
-          (production installs). "next" bumps each public package to a unique prerelease
-          version (e.g. 1.3.0-next.3) and publishes under the next tag for
-          release-candidate testing.
-        required: true
-        type: choice
-        options:
-          - latest
-          - next
-        default: latest
       git_ref:
-        description:
-          Tag or ref to publish (e.g. @hackney/mtfh-react-v1.3.0, main, or release-please
-          branch)
+        description: Tag or ref to publish (e.g. @hackney/mtfh-react-v1.3.0, main)
         required: true
         default: main
         type: string
@@ -39,21 +25,15 @@ permissions:
 jobs:
   publish:
     runs-on: ubuntu-latest
-    # - npm-prerelease: manual @next / RC publishes only
-    # - npm-release: production @latest (Release Please + manual hotfix republish)
-    environment:
-      ${{ github.event_name == 'workflow_dispatch' && inputs.channel == 'next' &&
-      'npm-prerelease' || 'npm-release' }}
+    environment: npm-release
     steps:
       - name: Resolve publish target
         id: target
         run: |
           if [ "${{ github.event_name }}" = "release" ]; then
             echo "ref=${{ github.event.release.tag_name }}" >> "$GITHUB_OUTPUT"
-            echo "channel=latest" >> "$GITHUB_OUTPUT"
           else
             echo "ref=${{ inputs.git_ref }}" >> "$GITHUB_OUTPUT"
-            echo "channel=${{ inputs.channel }}" >> "$GITHUB_OUTPUT"
           fi
 
       - uses: actions/checkout@v6
@@ -77,49 +57,13 @@ jobs:
       - name: Run tests
         run: npm run test:ci
 
-      - name: Resolve publish versions
-        id: version
-        run: |
-          CHANNEL="${{ steps.target.outputs.channel }}"
-
-          if [ "$CHANNEL" = "next" ]; then
-            for pkg_json in packages/*/package.json; do
-              NAME=$(node -p "require('./${pkg_json}').name")
-              PRIVATE=$(node -p "Boolean(require('./${pkg_json}').private)")
-              if [ "$PRIVATE" = "true" ]; then
-                continue
-              fi
-
-              BASE=$(node -p "require('./${pkg_json}').version")
-              PREFIX="${BASE}-next."
-              MAX_N=0
-              if VERSIONS=$(npm view "${NAME}" versions --json 2>/dev/null); then
-                MAX_N=$(echo "$VERSIONS" | jq --arg p "$PREFIX" '
-                  (if type == "array" then . else [.] end)
-                  | [.[] | select(startswith($p)) | .[$p | length:] | select(test("^[0-9]+$")) | tonumber]
-                  | max // 0
-                ')
-              fi
-              VERSION="${BASE}-next.$((MAX_N + 1))"
-              npm version "${VERSION}" --no-git-tag-version --workspace "${NAME}"
-              echo "Prepared ${NAME}@${VERSION}"
-            done
-          fi
-
-          echo "channel=${CHANNEL}" >> "$GITHUB_OUTPUT"
-          echo "Publishing workspace packages (dist-tag ${CHANNEL}) from ${{ steps.target.outputs.ref }}"
-
       - name: Publish packages
-        run:
-          npx lerna publish from-package --yes --dist-tag "${{
-          steps.target.outputs.channel }}"
+        run: npx lerna publish from-package --yes
 
       - name: Build Storybook
-        if: ${{ steps.target.outputs.channel == 'latest' }}
         run: npm run build-storybook
 
       - name: Deploy Storybook
-        if: ${{ steps.target.outputs.channel == 'latest' }}
         uses: JamesIves/github-pages-deploy-action@v4
         with:
           branch: gh-pages
@@ -127,12 +71,11 @@ jobs:
 
       - name: Summary
         run: |
-          CHANNEL="${{ steps.target.outputs.channel }}"
           REF="${{ steps.target.outputs.ref }}"
           {
             echo "### Packages published (trusted publisher / OIDC)"
             echo ""
-            echo "- **Dist-tag:** \`${CHANNEL}\`"
+            echo "- **Dist-tag:** \`latest\`"
             echo "- **Ref:** \`${REF}\`"
             echo ""
             echo "Published via \`lerna publish from-package\` for versions not already on npm."

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -11,8 +11,6 @@ permissions:
 jobs:
   release-please:
     runs-on: ubuntu-latest
-    outputs:
-      releases_created: ${{ steps.release.outputs.releases_created }}
     steps:
       - name: Generate token
         id: app-token
@@ -30,44 +28,5 @@ jobs:
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
 
-  publish-npm:
-    needs: release-please
-    if: ${{ needs.release-please.outputs.releases_created == 'true' }}
-    runs-on: ubuntu-latest
-    # contents: write is required for JamesIves/github-pages-deploy-action to push gh-pages
-    permissions:
-      contents: write
-    steps:
-      - uses: actions/checkout@v6
-        with:
-          fetch-depth: 0
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v6
-        with:
-          node-version-file: ".nvmrc"
-          registry-url: https://registry.npmjs.org
-          cache: npm
-
-      - name: Install modules
-        run: npm ci
-
-      - name: Build packages
-        run: npm run build
-
-      - name: Run tests
-        run: npm run test:ci
-
-      - name: Publish packages
-        run: npx lerna publish from-package --yes
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-
-      - name: Build Storybook
-        run: npm run build-storybook
-
-      - name: Deploy Storybook
-        uses: JamesIves/github-pages-deploy-action@v4
-        with:
-          branch: gh-pages
-          folder: storybook-static
+  # npm publish and Storybook deploy run in publish-npm.yml (trusted publisher)
+  # when GitHub Releases are created by Release Please.

--- a/README.md
+++ b/README.md
@@ -63,15 +63,6 @@ Publishing uses [npm trusted publishers](https://docs.npmjs.com/trusted-publishe
 [publish-npm.yml](.github/workflows/publish-npm.yml). Do **not** use a long-lived
 `NPM_TOKEN`.
 
-One-time setup (maintainers):
-
-1. Create a GitHub Environment **`npm-release`** (optional required reviewers).
-2. On [npmjs.com](https://www.npmjs.com/) for **each** published `@hackney/*` package, add
-   a trusted publisher:
-   - **Repository:** `LBHackney-IT/mtfh-frontend`
-   - **Workflow:** `publish-npm.yml` (filename must match exactly)
-   - **Environment:** `npm-release`
-
 Manual / hotfix republish: **Actions → Publish npm package → Run workflow** with a tag or
 `main` ref.
 

--- a/README.md
+++ b/README.md
@@ -49,11 +49,33 @@ Look through the various `packages/*` in this monorepo and their detailed Readme
    release PR with version bumps and `CHANGELOG.md` updates for affected packages.
 5. Release PRs are validated by
    [release-pr-build.yml](.github/workflows/release-pr-build.yml) (build, lint, test).
-6. Merge the release PR to `main`. Release Please tags the release and the publish
-   workflow builds packages and publishes to npm.
+6. Merge the release PR to `main`. Release Please creates GitHub Release(s); the
+   [Publish npm package](.github/workflows/publish-npm.yml) workflow builds packages and
+   publishes to npm using [trusted publishers](https://docs.npmjs.com/trusted-publishers)
+   (OIDC), then deploys Storybook to `gh-pages`.
 
 `@hackney/create-mfe` and `@hackney/generator-mfe` are versioned together (linked in
 `release-please-config.json`).
+
+### Publishing (OIDC / trusted publisher)
+
+Publishing uses [npm trusted publishers](https://docs.npmjs.com/trusted-publishers) via
+[publish-npm.yml](.github/workflows/publish-npm.yml). Do **not** use a long-lived
+`NPM_TOKEN`.
+
+One-time setup (maintainers):
+
+1. Create GitHub Environments **`npm-release`** and **`npm-prerelease`** (optional
+   required reviewers for production publishes).
+2. On [npmjs.com](https://www.npmjs.com/) for **each** published `@hackney/*` package, add
+   a trusted publisher:
+   - **Repository:** `LBHackney-IT/mtfh-frontend`
+   - **Workflow:** `publish-npm.yml` (filename must match exactly)
+   - **Environment:** `npm-release` (and separately `npm-prerelease` if you use `@next`)
+
+Manual / hotfix republish: **Actions → Publish npm package → Run workflow** with channel
+`latest` and a tag or `main` ref. For pre-release testing from a Release Please branch,
+use channel `next` (publishes unique `*-next.N` versions under the `next` tag).
 
 ### Repository secrets
 
@@ -62,4 +84,3 @@ lbh-frontend):
 
 - `RELEASE_PLEASE_APP_ID`
 - `RELEASE_PLEASE_PRIVATE_KEY`
-- `NPM_TOKEN`

--- a/README.md
+++ b/README.md
@@ -65,17 +65,15 @@ Publishing uses [npm trusted publishers](https://docs.npmjs.com/trusted-publishe
 
 One-time setup (maintainers):
 
-1. Create GitHub Environments **`npm-release`** and **`npm-prerelease`** (optional
-   required reviewers for production publishes).
+1. Create a GitHub Environment **`npm-release`** (optional required reviewers).
 2. On [npmjs.com](https://www.npmjs.com/) for **each** published `@hackney/*` package, add
    a trusted publisher:
    - **Repository:** `LBHackney-IT/mtfh-frontend`
    - **Workflow:** `publish-npm.yml` (filename must match exactly)
-   - **Environment:** `npm-release` (and separately `npm-prerelease` if you use `@next`)
+   - **Environment:** `npm-release`
 
-Manual / hotfix republish: **Actions → Publish npm package → Run workflow** with channel
-`latest` and a tag or `main` ref. For pre-release testing from a Release Please branch,
-use channel `next` (publishes unique `*-next.N` versions under the `next` tag).
+Manual / hotfix republish: **Actions → Publish npm package → Run workflow** with a tag or
+`main` ref.
 
 ### Repository secrets
 


### PR DESCRIPTION
## Summary
- Add `publish-npm.yml` (trusted publisher / OIDC) triggered on GitHub Release publish and manual `workflow_dispatch`, matching lbh-frontend’s production path.
- Remove token-based `lerna publish` (and Storybook deploy) from `release-please.yml`; Release Please now only cuts releases.
- Document the `npm-release` environment and per-package npm trusted publisher setup.

## Test plan
- [ ] Confirm a Release Please merge triggers `publish-npm.yml` on the release event without `NODE_AUTH_TOKEN`
- [ ] Manual dispatch with a tag or `main` ref works after trusted publisher setup