### PR TITLE
fix: clarify package README descriptions across the monorepo

### DIFF
--- a/packages/cli/readme.md
+++ b/packages/cli/readme.md
@@ -1,6 +1,6 @@
 # `@hackney/mtfh-cli`
 
-A CLI to help manage micro-frontend orchestration for MTFH.
+CLI for managing micro-frontend orchestration for Modern Tools for Housing.
 
 Requires **Node.js 24+**.
 

--- a/packages/create-mfe/README.md
+++ b/packages/create-mfe/README.md
@@ -1,6 +1,6 @@
 # `@hackney/create-mfe`
 
-Scaffolding utilities for Hackney micro-frontends.
+Scaffolding CLI for Hackney micro-frontend applications.
 
 Requires **Node.js 24+**.
 

--- a/packages/cypress/README.md
+++ b/packages/cypress/README.md
@@ -1,9 +1,8 @@
 # `@hackney/mtfh-cypress`
 
-This package is intended to be used in conjunction with a live environment that uses
-import-maps to resolve micro-frontends. It will stub an import-map with the URL defined in
-the env. This allows us to test a local MFE against an environment without deploying,
-while having access to the entire environment.
+Cypress helpers for Modern Tools for Housing. Intended for use with a live environment
+that resolves micro-frontends via import maps: it stubs the import map with the URL from
+the env so you can test a local MFE against that environment without deploying.
 
 Requires **Cypress 13+** and **Node.js 24+**.
 

--- a/packages/eslint-config/README.md
+++ b/packages/eslint-config/README.md
@@ -1,6 +1,6 @@
 # `@hackney/eslint-config`
 
-ESLint config for TypeScript and React projects.
+Shared ESLint configuration for Hackney TypeScript and React projects.
 
 Requires **ESLint 8**, **typescript-eslint 7**, and **Prettier 3** peer dependencies (see
 Installation).

--- a/packages/generator/README.md
+++ b/packages/generator/README.md
@@ -1,6 +1,6 @@
 # `@hackney/generator-mfe`
 
-Yeoman generator for Hackney micro-frontend applications. Used by
+Yeoman generator that scaffolds Hackney micro-frontend applications. Used by
 [`@hackney/create-mfe`](../create-mfe) and `@hackney/mtfh-cli` (`new` / `upgrade`).
 
 Requires **Node.js 24+**.

--- a/packages/prettier-config/README.md
+++ b/packages/prettier-config/README.md
@@ -1,6 +1,6 @@
 # `@hackney/prettier-config`
 
-A configuration for Prettier, to create consistency across Hackney projects.
+Shared Prettier configuration for Hackney front-end projects.
 
 ## Usage
 

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -1,8 +1,8 @@
 # `@hackney/mtfh-react`
 
-LBH React design-system components for Modern Tools for Housing. Built on
-[lbh-frontend](https://github.com/LBHackney-IT/lbh-frontend) / GOV.UK Frontend styles and
-patterns.
+LBH React design-system components for Modern Tools for Housing, built on
+[lbh-frontend](https://github.com/LBHackney-IT/lbh-frontend) and GOV.UK Frontend styles
+and patterns.
 
 ## Installation
 

--- a/packages/system/README.md
+++ b/packages/system/README.md
@@ -1,6 +1,6 @@
 # `@hackney/mtfh-system`
 
-Shared design tokens and breakpoint helpers for Modern Tools for Housing frontends.
+Shared design tokens and breakpoint helpers for Modern Tools for Housing front-ends.
 
 ## Installation
 

--- a/packages/test-utils/README.md
+++ b/packages/test-utils/README.md
@@ -1,6 +1,6 @@
-# `test-utils`
+# `@hackney/mtfh-test-utils`
 
-Testing utilities for Jest utilising the `@testing-library` and `msw` frameworks.
+Shared Jest testing utilities built on `@testing-library` and `msw`.
 
 Supports React **17 | 18 | 19** and MSW **2**.
 

--- a/packages/webpack-import-map-plugin/README.md
+++ b/packages/webpack-import-map-plugin/README.md
@@ -1,6 +1,6 @@
 # `@hackney/webpack-import-map-plugin`
 
-Import Map Webpack Plugin will produce an import-map of built files.
+Webpack plugin that emits an import map of built micro-frontend files.
 
 ## Usage
 


### PR DESCRIPTION
## Summary
- Tiny README wording tweaks under every `packages/*` so Release Please opens patch releases for each published package.

## Why
Exercise the new OIDC `publish-npm.yml` path end-to-end with a low-risk, docs-only bump across the monorepo.

## After merge
1. Confirm Release Please opens a release PR covering the touched packages.
2. Merge that release PR.
3. Confirm **Publish npm package** runs on the GitHub Release(s) (OIDC / `npm-release`).

## Test plan
- [ ] PR CI green
- [ ] Release Please creates a release PR after this merges
- [ ] OIDC publish succeeds for the released packages