### PR TITLE
fix(ci): skip published versions and decouple Storybook deploy

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -22,9 +22,8 @@ permissions:
   id-token: write
 
 jobs:
-  publish:
+  build-test:
     runs-on: ubuntu-latest
-    environment: npm-release
     steps:
       - uses: actions/checkout@v6
         with:
@@ -47,8 +46,116 @@ jobs:
       - name: Run tests
         run: npm run test:ci
 
+  publish:
+    needs: build-test
+    runs-on: ubuntu-latest
+    environment: npm-release
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.git_ref }}
+          fetch-depth: 0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version-file: ".nvmrc"
+          registry-url: https://registry.npmjs.org
+          package-manager-cache: false
+
+      - name: Install modules
+        run: npm ci
+
+      - name: Build packages
+        run: npm run build
+
+      - name: Resolve unpublished packages
+        id: unpublished
+        run: |
+          SCOPES=()
+          while IFS= read -r pkg_json; do
+            NAME=$(node -p "require('./${pkg_json}').name")
+            VERSION=$(node -p "require('./${pkg_json}').version")
+            PRIVATE=$(node -p "Boolean(require('./${pkg_json}').private)")
+            if [ "$PRIVATE" = "true" ]; then
+              continue
+            fi
+
+            if npm view "${NAME}@${VERSION}" version >/dev/null 2>&1; then
+              echo "Skip ${NAME}@${VERSION} (already on npm)"
+            else
+              echo "Queue ${NAME}@${VERSION}"
+              SCOPES+=("${NAME}")
+            fi
+          done < <(find packages -mindepth 2 -maxdepth 2 -name package.json | sort)
+
+          if [ "${#SCOPES[@]}" -eq 0 ]; then
+            echo "has_packages=false" >> "$GITHUB_OUTPUT"
+            echo "No unpublished package versions to publish."
+            exit 0
+          fi
+
+          {
+            echo "has_packages=true"
+            echo "scopes<<EOF"
+            printf '%s\n' "${SCOPES[@]}"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+
+          echo "Will publish: ${SCOPES[*]}"
+
       - name: Publish packages
-        run: npx lerna publish from-package --yes
+        if: ${{ steps.unpublished.outputs.has_packages == 'true' }}
+        env:
+          SCOPES: ${{ steps.unpublished.outputs.scopes }}
+        run: |
+          ARGS=()
+          while IFS= read -r name; do
+            [ -z "$name" ] && continue
+            ARGS+=(--scope "$name")
+          done <<< "$SCOPES"
+
+          npx lerna publish from-package --yes "${ARGS[@]}"
+
+      - name: Summary
+        run: |
+          {
+            echo "### Packages published (trusted publisher / OIDC)"
+            echo ""
+            echo "- **Dist-tag:** \`latest\`"
+            echo "- **Ref:** \`${{ inputs.git_ref }}\`"
+            echo "- **Queued scopes:**"
+            if [ "${{ steps.unpublished.outputs.has_packages }}" = "true" ]; then
+              echo '```'
+              echo "${{ steps.unpublished.outputs.scopes }}"
+              echo '```'
+            else
+              echo "_None — all package.json versions already on npm._"
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"
+
+  # Independent of publish success so a TLOG/retry failure cannot block gh-pages.
+  storybook:
+    needs: build-test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.git_ref }}
+          fetch-depth: 0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version-file: ".nvmrc"
+          registry-url: https://registry.npmjs.org
+          package-manager-cache: false
+
+      - name: Install modules
+        run: npm ci
+
+      - name: Build packages
+        run: npm run build
 
       - name: Build Storybook
         run: npm run build-storybook
@@ -58,14 +165,3 @@ jobs:
         with:
           branch: gh-pages
           folder: storybook-static
-
-      - name: Summary
-        run: |
-          {
-            echo "### Packages published (trusted publisher / OIDC)"
-            echo ""
-            echo "- **Dist-tag:** \`latest\`"
-            echo "- **Ref:** \`${{ inputs.git_ref }}\`"
-            echo ""
-            echo "Published via \`lerna publish from-package\` for versions not already on npm."
-          } >> "$GITHUB_STEP_SUMMARY"

--- a/README.md
+++ b/README.md
@@ -50,10 +50,10 @@ Look through the various `packages/*` in this monorepo and their detailed Readme
 5. Release PRs are validated by
    [release-pr-build.yml](.github/workflows/release-pr-build.yml) (build, lint, test).
 6. Merge the release PR to `main`. Release Please creates GitHub Release(s) and dispatches
-   a **single** [Publish npm package](.github/workflows/publish-npm.yml) run, which builds
-   packages and publishes to npm using
-   [trusted publishers](https://docs.npmjs.com/trusted-publishers) (OIDC), then deploys
-   Storybook to `gh-pages`.
+   a **single** [Publish npm package](.github/workflows/publish-npm.yml) run. That
+   workflow builds/tests, publishes only package versions not already on npm (OIDC trusted
+   publisher), and deploys Storybook to `gh-pages` in a separate job so a publish retry
+   failure cannot block the site.
 
 `@hackney/create-mfe` and `@hackney/generator-mfe` are versioned together (linked in
 `release-please-config.json`).
@@ -65,7 +65,8 @@ Publishing uses [npm trusted publishers](https://docs.npmjs.com/trusted-publishe
 `NPM_TOKEN`.
 
 Manual / hotfix republish: **Actions → Publish npm package → Run workflow** with a tag or
-`main` ref (publishes any versions in `package.json` that are not yet on npm).
+`main` ref. Already-published versions are skipped (avoids Sigstore TLOG `409` errors on
+retry).
 
 ### Repository secrets
 

--- a/README.md
+++ b/README.md
@@ -65,8 +65,7 @@ Publishing uses [npm trusted publishers](https://docs.npmjs.com/trusted-publishe
 `NPM_TOKEN`.
 
 Manual / hotfix republish: **Actions → Publish npm package → Run workflow** with a tag or
-`main` ref. Already-published versions are skipped (avoids Sigstore TLOG `409` errors on
-retry).
+`main` ref (publishes any versions in `package.json` that are not yet on npm).
 
 ### Repository secrets
 


### PR DESCRIPTION
## Summary
- Before \`lerna publish\`, resolve which \`@hackney/*\` versions are not yet on npm and only publish those. Avoids workflow being blocked by 'failure' to publish.
- Split \`publish-npm.yml\` into \`build-test\`, \`publish\`, and \`storybook\` jobs so Storybook/gh-pages is not blocked when publish partially fails.

## Test plan
- [x] Manually run **Publish npm package** on \`main\` when some versions are already published — publish job should skip them / exit 0 if nothing left
- [ ] Confirm Storybook job stays green even if publish fails
- [ ] Confirm a full unpublished set still publishes as before