### PR TITLE
fix(ci): publish filtered packages with npm workspaces

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -109,13 +109,21 @@ jobs:
         env:
           SCOPES: ${{ steps.unpublished.outputs.scopes }}
         run: |
-          ARGS=()
+          # Lerna 9 publish no longer supports --scope; publish each queued
+          # workspace package with npm (OIDC / trusted publisher still applies).
+          failed=0
           while IFS= read -r name; do
             [ -z "$name" ] && continue
-            ARGS+=(--scope "$name")
+            echo "Publishing ${name}..."
+            if ! npm publish --workspace "${name}" --access public; then
+              echo "::error::Failed to publish ${name}"
+              failed=1
+            fi
           done <<< "$SCOPES"
 
-          npx lerna publish from-package --yes "${ARGS[@]}"
+          if [ "$failed" -ne 0 ]; then
+            exit 1
+          fi
 
       - name: Summary
         run: |
@@ -132,6 +140,7 @@ jobs:
             else
               echo "_None — all package.json versions already on npm._"
             fi
+            echo "Published via \`npm publish --workspace\` for versions not already on npm."
           } >> "$GITHUB_STEP_SUMMARY"
 
   # Independent of publish success so a TLOG/retry failure cannot block gh-pages.

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -109,8 +109,6 @@ jobs:
         env:
           SCOPES: ${{ steps.unpublished.outputs.scopes }}
         run: |
-          # Lerna 9 publish no longer supports --scope; publish each queued
-          # workspace package with npm (OIDC / trusted publisher still applies).
           failed=0
           while IFS= read -r name; do
             [ -z "$name" ] && continue


### PR DESCRIPTION
## Summary
- Lerna 9 \`publish\` rejects \`--scope\` (\`Unknown argument: scope\`).
- Keep the unpublished-version filter, but publish each queued package with \`npm publish --workspace\` (OIDC trusted publisher still applies).

## Test plan
- [ ] Re-run **Publish npm package** on \`main\`
- [ ] Confirm already-published packages are skipped and remaining ones publish without the scope error